### PR TITLE
Add local bases

### DIFF
--- a/examples/basis_test.c
+++ b/examples/basis_test.c
@@ -201,7 +201,7 @@ static void regression_multid()
   {
     double err;
     int nb_variates = 2; /* functions with values in R^2 */
-    int n_intervals = 30; /*  number of intervals  */
+    int n_intervals = 50; /*  number of intervals  */
     PnlBasis *basis = pnl_basis_create_local_regular(n_intervals, nb_variates);
     err = regression_multid_aux(function2d_3, basis, MEAN_ERR);
     pnl_test_eq_abs(err, 0., 1E-2, "pnl_basis_eval (local basis)", "local basis with 50 intervals");

--- a/man/bases.tex
+++ b/man/bases.tex
@@ -5,7 +5,12 @@ To use these functionalities, you should include \verb!pnl/pnl_basis.h!.
 
 \describestruct{PnlBasis}
 \begin{verbatim}
-struct PnlBasis_t {
+struct _PnlBasis
+{
+  /**
+   * Must be the first element in order for the object mechanism to work
+   * properly. This allows any PnlBasis pointer to be cast to a PnlObject
+   */
   PnlObject     object;
   /** The basis type */
   int           id;
@@ -21,22 +26,26 @@ struct PnlBasis_t {
   PnlSpMatInt  *SpT;
   /** The number of functions in the tensor #T */
   int           len_T;
-  /** The i-th element of the one dimensional basis. */
-  double      (*f)(double    x, int i);
-  /** The first derivative of i-th element of the one dimensional basis */
-  double      (*Df)(double   x, int i);
-  /** The second derivative of the i-th element of the one dimensional basis */
-  double      (*D2f)(double  x, int i);
-  /** TRUE if the basis is reduced */
+  /** Compute the i-th element of the one dimensional basis.  As a convention, (*f)(x, 0) MUST be equal to 1 */
+  double      (*f)(double x, int i, int dim, void *params);
+  /** Compute the first derivative of i-th element of the one dimensional basis */
+  double      (*Df)(double x, int i, int dim, void *params);
+  /** Compute the second derivative of the i-th element of the one dimensional basis */
+  double      (*D2f)(double x, int i, int dim, void *params);
+  /** PNL_TRUE if the basis is reduced */
   int           isreduced;
   /** The center of the domain */
   double       *center;
   /** The inverse of the scaling factor to map the domain to [-1, 1]^nb_variates */
   double       *scale;
   /** An array of additional functions */
-  PnlRnFuncR  *func_list;
+  PnlRnFuncR   *func_list;
   /** The number of functions in #func_list */
-  int          len_func_list;
+  int           len_func_list;
+  /** Extra parameters to pass to basis functions */
+  void         *params;
+  /** Size of params in bytes to be passed to malloc */
+  size_t        params_size;
 };
 \end{verbatim}
 
@@ -82,22 +91,22 @@ If $G$ is a real valued standard normal random variable, ${\mathbb E}[H_n(G) H_m
 \subsection{Functions}
 
 \begin{itemize}
-\item \describefun{int}{pnl_basis_type_register}{const char *name, double (*f)(double, int), double (*Df)(double, int), double (*D2f)(double, int)}
+\item \describefun{int}{pnl_basis_type_register}{const char *name, double (*f)(double, int, int, void), double (*Df)(double, int, int, void), double (*D2f)(double, int, int, void), int is_orthogonal}
 \sshortdescribe Register a new basis type and return the index to be passed to
 \reffun{pnl_basis_create} . The variable \var{name} is a unique
 string identifier of the family. The variables \var{f}, \var{Df}, \var{D2f} are
 the one dimensional basis functions, its first and second order derivatives.
 Each of these functions must return a \var{double} and take two arguments : the
 first one is the point at which evaluating the basis functions, the second one
-is the index of function. Here is a toy example to show how the canonical basis
+is the index of function. The var{is_orthogonal} if the elements of the basis are orthogonal for the $L^2$ scalar product. Here is a toy example to show how the canonical basis
 is registered (this family is actually already available with the id
 PNL_BASIS_CANONICAL, so the following example may look a little fake)
 \begin{verbatim}
-  double f(double x, int n) { return pnl_pow_i(x, n); }
-  double Df(double x, int n) { return n * pnl_pow_i(x, n-1); }
-  double f(double x, int n) { return n * (n-1) * pnl_pow_i(x, n-2); }
+  double f(double x, int n, int dim, void *params) { return pnl_pow_i(x, n); }
+  double Df(double x, int n, int dim, void *params) { return n * pnl_pow_i(x, n-1); }
+  double f(double x, int n, int dim, void *params) { return n * (n-1) * pnl_pow_i(x, n-2); }
 
-  int id = pnl_basis_register ("Canonic", f, Df, D2f);
+  int id = pnl_basis_register ("Canonic", f, Df, D2f, PNL_FALSE);
   /*
    * B is the Canonical basis of polynomials with degree less or equal than 2 in
    * dimension 5.
@@ -110,8 +119,7 @@ PNL_BASIS_CANONICAL, so the following example may look a little fake)
 
 \item \describefun{void}{pnl_basis_print}{const \PnlBasis \ptr B}
   \sshortdescribe Print the characteristics of a basis.
-  
-  
+
 \item \describefun{\PnlBasis *}{pnl_basis_create}{int index, int
     nb_func, int nb_variates}
   \sshortdescribe Create a \PnlBasis for the family
@@ -125,8 +133,8 @@ PNL_BASIS_CANONICAL, so the following example may look a little fake)
   defined by \var{index} (see Table~\ref{basis_index} and \reffun{pnl_basis_type_register}) with total degree less
   or equal than \var{degree} and \var{nb_variates} variates. The total degree is
   the sum of the partial degrees.\\
-  For instance, calling \verb!pnl_basis_create_from_degree (index, 2, 4)! is
-  equivalent to calling \verb!pnl_basis_create_from_tensor (index, T)! where
+  For instance, calling \verb!pnl_basis_create_from_degree(index, 2, 4)! is
+  equivalent to calling \verb!pnl_basis_create_from_tensor(index, T)! where
   \var{T} is given by
   \[ \left(
     \begin{array}{cccc}
@@ -209,6 +217,9 @@ PNL_BASIS_CANONICAL, so the following example may look a little fake)
     {\alpha_i}^q \right)^{1/q} \leq degree$. This kind of basis based on an
   hyperbolic set of indices gives priority to polynomials associated to low
   order interaction.
+
+\item \describefun{\PnlBasis\ptr}{pnl_basis_create_local}{int \ptr n_intervals, int space_dim}
+  \sshortdescribe Create a local bases on $(-1, 1)^{\var{space_dim}}$ with \var{n_intervals[i]} along dimension \var{i} for $i \in \{1,\dots,\var{space_dim}\}$. This basis is orthogonal. Note that this basis is not differentiable.
 
 \item  \describefun{void}{pnl_basis_free}{\PnlBasis \ptr\ptr basis}
   \sshortdescribe Free a \PnlBasis created by

--- a/src/include/pnl/pnl_basis.h
+++ b/src/include/pnl/pnl_basis.h
@@ -69,11 +69,11 @@ struct _PnlBasis
   /** The number of functions in the tensor #T */
   int           len_T;
   /** Compute the i-th element of the one dimensional basis.  As a convention, (*f)(x, 0) MUST be equal to 1 */
-  double      (*f)(double x, int i, void *params);
+  double      (*f)(double x, int i, int dim, void *params);
   /** Compute the first derivative of i-th element of the one dimensional basis */
-  double      (*Df)(double x, int i, void *params);
+  double      (*Df)(double x, int i, int dim, void *params);
   /** Compute the second derivative of the i-th element of the one dimensional basis */
-  double      (*D2f)(double x, int i, void *params);
+  double      (*D2f)(double x, int i, int dim, void *params);
   /** PNL_TRUE if the basis is reduced */
   int           isreduced;
   /** The center of the domain */
@@ -90,7 +90,7 @@ struct _PnlBasis
   size_t        params_size;
 };
 
-extern int pnl_basis_type_register(const char *name, double (*f)(double, int, void*), double (*Df)(double, int, void*), double (*D2f)(double, int, void*));
+extern int pnl_basis_type_register(const char *name, double (*f)(double, int, int, void*), double (*Df)(double, int, int, void*), double (*D2f)(double, int, int, void*));
 extern PnlBasis* pnl_basis_new();
 extern PnlBasis* pnl_basis_create(int index, int nb_func, int space_dim);
 extern PnlBasis* pnl_basis_create_from_degree(int index, int degree, int space_dim);
@@ -155,7 +155,7 @@ PNL_INLINE_FUNC double pnl_basis_i(const PnlBasis *b, const double *x, int i)
         {
           const int j = b->SpT->J[k];
           const int Tij = b->SpT->array[k];
-          aux *= (b->f)((x[j] - b->center[j]) * b->scale[j], Tij, b->params);
+          aux *= (b->f)((x[j] - b->center[j]) * b->scale[j], Tij, j, b->params);
         }
     }
   else
@@ -164,7 +164,7 @@ PNL_INLINE_FUNC double pnl_basis_i(const PnlBasis *b, const double *x, int i)
         {
           const int j = b->SpT->J[k];
           const int Tij = b->SpT->array[k];
-          aux *= (b->f)(x[j], Tij, b->params);
+          aux *= (b->f)(x[j], Tij, j, b->params);
         }
     }
   return aux;

--- a/src/include/pnl/pnl_basis.h
+++ b/src/include/pnl/pnl_basis.h
@@ -90,7 +90,7 @@ struct _PnlBasis
   size_t        params_size;
 };
 
-extern int pnl_basis_type_register(const char *name, double (*f)(double, int, int, void*), double (*Df)(double, int, int, void*), double (*D2f)(double, int, int, void*));
+extern int pnl_basis_type_register(const char *name, double (*f)(double, int, int, void*), double (*Df)(double, int, int, void*), double (*D2f)(double, int, int, void*), int is_orthogonal);
 extern PnlBasis* pnl_basis_new();
 extern PnlBasis* pnl_basis_create(int index, int nb_func, int space_dim);
 extern PnlBasis* pnl_basis_create_from_degree(int index, int degree, int space_dim);

--- a/src/include/pnl/pnl_basis.h
+++ b/src/include/pnl/pnl_basis.h
@@ -69,11 +69,11 @@ struct _PnlBasis
   /** The number of functions in the tensor #T */
   int           len_T;
   /** Compute the i-th element of the one dimensional basis.  As a convention, (*f)(x, 0) MUST be equal to 1 */
-  double      (*f)(double    x, int i);
+  double      (*f)(double x, int i, void *params);
   /** Compute the first derivative of i-th element of the one dimensional basis */
-  double      (*Df)(double   x, int i);
+  double      (*Df)(double x, int i, void *params);
   /** Compute the second derivative of the i-th element of the one dimensional basis */
-  double      (*D2f)(double  x, int i);
+  double      (*D2f)(double x, int i, void *params);
   /** PNL_TRUE if the basis is reduced */
   int           isreduced;
   /** The center of the domain */
@@ -81,12 +81,16 @@ struct _PnlBasis
   /** The inverse of the scaling factor to map the domain to [-1, 1]^nb_variates */
   double       *scale;
   /** An array of additional functions */
-  PnlRnFuncR  *func_list;
+  PnlRnFuncR   *func_list;
   /** The number of functions in #func_list */
-  int          len_func_list;
+  int           len_func_list;
+  /** Extra parameters to pass to basis functions */
+  void         *params;
+  /** Size of params in bytes to be passed to malloc */
+  size_t        params_size;
 };
 
-extern int pnl_basis_type_register(const char *name, double (*f)(double, int), double (*Df)(double, int), double (*D2f)(double, int));
+extern int pnl_basis_type_register(const char *name, double (*f)(double, int, void*), double (*Df)(double, int, void*), double (*D2f)(double, int, void*));
 extern PnlBasis* pnl_basis_new();
 extern PnlBasis* pnl_basis_create(int index, int nb_func, int space_dim);
 extern PnlBasis* pnl_basis_create_from_degree(int index, int degree, int space_dim);
@@ -151,7 +155,7 @@ PNL_INLINE_FUNC double pnl_basis_i(const PnlBasis *b, const double *x, int i)
         {
           const int j = b->SpT->J[k];
           const int Tij = b->SpT->array[k];
-          aux *= (b->f)((x[j] - b->center[j]) * b->scale[j], Tij);
+          aux *= (b->f)((x[j] - b->center[j]) * b->scale[j], Tij, b->params);
         }
     }
   else
@@ -160,7 +164,7 @@ PNL_INLINE_FUNC double pnl_basis_i(const PnlBasis *b, const double *x, int i)
         {
           const int j = b->SpT->J[k];
           const int Tij = b->SpT->array[k];
-          aux *= (b->f)(x[j], Tij);
+          aux *= (b->f)(x[j], Tij, b->params);
         }
     }
   return aux;

--- a/src/include/pnl/pnl_basis.h
+++ b/src/include/pnl/pnl_basis.h
@@ -18,8 +18,7 @@ extern "C" {
 
 /*@{*/
 
-/* basis indices must start from 0 because they serve an index for the
- * PnlBasisTypeTab array */
+/* basis indices must start from 0 because they serve as an index for the PnlBasisTypeTab array */
 enum {PNL_BASIS_NULL=-1, PNL_BASIS_CANONICAL=0, PNL_BASIS_HERMITE=1, PNL_BASIS_TCHEBYCHEV=2, PNL_BASIS_LOCAL=3 };
 /* synonymous for compatibility purposes */
 #define CANONICAL PNL_BASIS_CANONICAL

--- a/src/include/pnl/pnl_basis.h
+++ b/src/include/pnl/pnl_basis.h
@@ -20,7 +20,7 @@ extern "C" {
 
 /* basis indices must start from 0 because they serve an index for the
  * PnlBasisTypeTab array */
-enum {PNL_BASIS_NULL=-1, PNL_BASIS_CANONICAL=0, PNL_BASIS_HERMITE=1, PNL_BASIS_TCHEBYCHEV=2 };
+enum {PNL_BASIS_NULL=-1, PNL_BASIS_CANONICAL=0, PNL_BASIS_HERMITE=1, PNL_BASIS_TCHEBYCHEV=2, PNL_BASIS_LOCAL=3 };
 /* synonymous for compatibility purposes */
 #define CANONICAL PNL_BASIS_CANONICAL
 #define HERMITIAN PNL_BASIS_HERMITE
@@ -94,6 +94,8 @@ extern int pnl_basis_type_register(const char *name, double (*f)(double, int, in
 extern PnlBasis* pnl_basis_new();
 extern PnlBasis* pnl_basis_create(int index, int nb_func, int space_dim);
 extern PnlBasis* pnl_basis_create_from_degree(int index, int degree, int space_dim);
+extern PnlBasis* pnl_basis_create_local(int *n_intervals, int space_dim);
+extern PnlBasis* pnl_basis_create_local_regular(int n_intervals, int space_dim);
 extern PnlBasis* pnl_basis_create_from_prod_degree(int index, int degree, int nb_variates);
 extern PnlBasis* pnl_basis_create_from_hyperbolic_degree(int index, double degree, double q, int n);
 extern void pnl_basis_clone(PnlBasis *dest, const PnlBasis *src);

--- a/src/include/pnl/pnl_basis.h
+++ b/src/include/pnl/pnl_basis.h
@@ -105,6 +105,7 @@ extern PnlBasis* pnl_basis_create_from_tensor( int index, const PnlMatInt *T);
 extern void pnl_basis_del_elt(PnlBasis *B, const PnlVectInt *d);
 extern void pnl_basis_del_elt_i(PnlBasis *B, int i);
 extern void pnl_basis_add_elt(PnlBasis *B, const PnlVectInt *d);
+extern int pnl_basis_local_get_index(const PnlBasis *basis, const double *x);
 extern void pnl_basis_set_domain(PnlBasis *B, const PnlVect *xmin, const PnlVect *xmax);
 extern void pnl_basis_set_reduced(PnlBasis *B, const PnlVect *center, const PnlVect *scale);
 extern void pnl_basis_free(PnlBasis **basis);

--- a/src/include/pnl/pnl_basis.h
+++ b/src/include/pnl/pnl_basis.h
@@ -98,7 +98,8 @@ extern PnlBasis* pnl_basis_create_from_prod_degree(int index, int degree, int nb
 extern PnlBasis* pnl_basis_create_from_hyperbolic_degree(int index, double degree, double q, int n);
 extern void pnl_basis_clone(PnlBasis *dest, const PnlBasis *src);
 extern PnlBasis* pnl_basis_copy(const PnlBasis *B);
-extern void  pnl_basis_set_from_tensor(PnlBasis *b, int index, const PnlMatInt *T);
+extern void pnl_basis_set_type(PnlBasis *B, int index);
+extern void  pnl_basis_set_from_tensor(PnlBasis *b, const PnlMatInt *T);
 extern PnlBasis* pnl_basis_create_from_tensor( int index, const PnlMatInt *T);
 extern void pnl_basis_del_elt(PnlBasis *B, const PnlVectInt *d);
 extern void pnl_basis_del_elt_i(PnlBasis *B, int i);

--- a/src/interpol/basis.c
+++ b/src/interpol/basis.c
@@ -453,9 +453,10 @@ static PnlMatInt *compute_tensor_from_hyperbolic_degree(double degree, double q,
  *  Canonical polynomials
  *  @param x the address of a real number
  *  @param l the index of the polynomial to be evaluated
+ *  @param dim the index of the component on which the function is applied
  *  @param params extra parameters
  */
-static double CanonicalD1(double x, int l, void *params)
+static double CanonicalD1(double x, int l, int dim, void *params)
 {
   return pnl_pow_i(x, l);
 }
@@ -464,9 +465,10 @@ static double CanonicalD1(double x, int l, void *params)
  *  First derivative of the Canonical polynomials
  *  @param x the address of a real number
  *  @param l the index of the polynomial whose first derivative is to be evaluated
+ *  @param dim the index of the component on which the function is applied
  *  @param params extra parameters
  */
-static double DCanonicalD1(double x, int l, void *params)
+static double DCanonicalD1(double x, int l, int dim, void *params)
 {
   if (l == 0) return 0.;
   return l * pnl_pow_i(x, l - 1);
@@ -476,9 +478,10 @@ static double DCanonicalD1(double x, int l, void *params)
  *  Second derivative of the Canonical polynomials
  *  @param x the address of a real number
  *  @param l the index of the polynomial whose second derivative is to be evaluated
+ *  @param dim the index of the component on which the function is applied
  *  @param params extra parameters
  */
-static double D2CanonicalD1(double x, int l, void *params)
+static double D2CanonicalD1(double x, int l, int dim, void *params)
 {
   if (l <= 1) return 0.;
   return l * (l - 1) * pnl_pow_i(x, l - 2);
@@ -512,9 +515,10 @@ static double Hermite_rec(double x, int n, int n0, double *f_n, double *f_n_1)
  *  Hermite polynomials
  *  @param x the address of a real number
  *  @param n the index of the polynomial to be evaluated
+ *  @param dim the index of the component on which the function is applied
  *  @param params extra parameters
  */
-static double HermiteD1(double x, int n, void *params)
+static double HermiteD1(double x, int n, int dim, void *params)
 {
   double val = x;
   double val2;
@@ -542,8 +546,8 @@ static double HermiteD1(double x, int n, void *params)
       val2 = val * val;
       return (((val2 - 21.) * val2 + 105.) * val2 - 105) * val;
     default:
-      f_n = HermiteD1(x, 7, params);
-      f_n_1 = HermiteD1(x, 6, params);
+      f_n = HermiteD1(x, 7, dim, params);
+      f_n_1 = HermiteD1(x, 6, dim, params);
       return Hermite_rec(x, n, 7, &f_n, &f_n_1);
     }
 }
@@ -554,10 +558,10 @@ static double HermiteD1(double x, int n, void *params)
  *  @param n the index of the polynomial whose derivative is to be evaluated
  *  @param params extra parameters
  */
-static double DHermiteD1(double x, int n, void *params)
+static double DHermiteD1(double x, int n, int dim, void *params)
 {
   if (n == 0) return 0.;
-  else return n * HermiteD1(x, n - 1, params);
+  else return n * HermiteD1(x, n - 1, dim, params);
 
 }
 
@@ -565,12 +569,13 @@ static double DHermiteD1(double x, int n, void *params)
  *  Second derivative of the Hermite polynomials
  *  @param x the address of a real number
  *  @param n the index of the polynomial whose second derivative is to be evaluated
+ *  @param dim the index of the component on which the function is applied
  *  @param params extra parameters
  */
-static double D2HermiteD1(double x, int n, void *params)
+static double D2HermiteD1(double x, int n, int dim, void *params)
 {
   if (n == 0 || n == 1) return 0.;
-  return n * (n - 1) * HermiteD1(x, n - 2, params);
+  return n * (n - 1) * HermiteD1(x, n - 2, dim, params);
 }
 
 /**
@@ -601,9 +606,10 @@ static double Tchebychev_rec(double x, int n, int n0, double *f_n0, double *f_n1
  *  Tchebytchev polynomials of any order
  *  @param x the address of a real number
  *  @param n the order of the polynomial to be evaluated
+ *  @param dim the index of the component on which the function is applied
  *  @param params extra parameters
  */
-static double TchebychevD1(double x, int n, void *params)
+static double TchebychevD1(double x, int n, int dim, void *params)
 {
   double val = x;
   double val2, val3, val4;
@@ -636,8 +642,8 @@ static double TchebychevD1(double x, int n, void *params)
       val4 = val2 * val2;
       return (64. * val4 - 112. * val2 + 56) * val3 - 7. * val;
     default :
-      f_n = TchebychevD1(x, 7, params);
-      f_n_1 = TchebychevD1(x, 6, params);
+      f_n = TchebychevD1(x, 7, dim, params);
+      f_n_1 = TchebychevD1(x, 6, dim, params);
       return Tchebychev_rec(x, n, 7, &f_n, &f_n_1);
     }
 }
@@ -672,9 +678,10 @@ static double DTchebychev_rec(double x, int n, int n0, double *f_n, double *f_n_
  *  First derivative of the Tchebytchev polynomials
  *  @param x the address of a real number
  *  @param n the index of the polynomial whose first derivative is to be evaluated
+ *  @param dim the index of the component on which the function is applied
  *  @param params extra parameters
  */
-static double DTchebychevD1(double x, int n, void *params)
+static double DTchebychevD1(double x, int n, int dim, void *params)
 {
   double val = x;
   double val2, val4;
@@ -703,8 +710,8 @@ static double DTchebychevD1(double x, int n, void *params)
       val4 = val2 * val2;
       return (448. * val4 - 560. * val2 + 168) * val2 - 7.;
     default :
-      f_n = DTchebychevD1(x, 7, params);
-      f_n_1 = DTchebychevD1(x, 6, params);
+      f_n = DTchebychevD1(x, 7, dim, params);
+      f_n_1 = DTchebychevD1(x, 6, dim, params);
       return DTchebychev_rec(x, n, 7, &f_n, &f_n_1);
     }
 }
@@ -718,9 +725,10 @@ static double DTchebychevD1(double x, int n, void *params)
  *  @param n0 rank of initialization
  *  @param f_n used to store the derivative of the polynomial of order n0
  *  @param f_n_1 used to store the derivative of  the polynomial of order n0 - 1
+ *  @param dim the index of the component on which the function is applied
  *  @param params extra parameters
  */
-static double D2Tchebychev_rec(double x, int n, int n0, double *f_n, double *f_n_1, void *params)
+static double D2Tchebychev_rec(double x, int n, int n0, double *f_n, double *f_n_1, int dim, void *params)
 {
   if (n == n0)
     {
@@ -729,9 +737,9 @@ static double D2Tchebychev_rec(double x, int n, int n0, double *f_n, double *f_n
   else
     {
       double save = *f_n;
-      *f_n = 2 * x * (*f_n) - (*f_n_1) + 4 * DTchebychevD1(x, n0, params);
+      *f_n = 2 * x * (*f_n) - (*f_n_1) + 4 * DTchebychevD1(x, n0, dim, params);
       *f_n_1 = save;
-      return D2Tchebychev_rec(x, n, n0 + 1, f_n, f_n_1, params);
+      return D2Tchebychev_rec(x, n, n0 + 1, f_n, f_n_1, dim, params);
     }
 }
 
@@ -739,9 +747,10 @@ static double D2Tchebychev_rec(double x, int n, int n0, double *f_n, double *f_n
  *  Second derivative of the Tchebytchev polynomials
  *  @param x the address of a real number
  *  @param n the index of the polynomial whose second derivative is to be evaluated
+ *  @param dim the index of the component on which the function is applied
  *  @param params extra parameters
  */
-static double D2TchebychevD1(double x, int n, void *params)
+static double D2TchebychevD1(double x, int n, int dim, void *params)
 {
   double val = x;
   double val2, val4;
@@ -770,9 +779,9 @@ static double D2TchebychevD1(double x, int n, void *params)
       val4 = val2 * val2;
       return (2688. * val4 - 2240. * val2 + 336) * val;
     default :
-      f_n = D2TchebychevD1(x, 7, params);
-      f_n_1 = D2TchebychevD1(x, 6, params);
-      return D2Tchebychev_rec(x, n, 7, &f_n, &f_n_1, params);
+      f_n = D2TchebychevD1(x, 7, dim, params);
+      f_n_1 = D2TchebychevD1(x, 6, dim, params);
+      return D2Tchebychev_rec(x, n, 7, &f_n, &f_n_1, dim, params);
     }
 }
 
@@ -784,9 +793,9 @@ struct PnlBasisType_t
 {
   int id;
   const char *label;
-  double (*f)(double x, int l, void *params);
-  double (*Df)(double x, int l, void *params);
-  double (*D2f)(double x, int l, void *params);
+  double (*f)(double x, int l, int dim, void *params);
+  double (*Df)(double x, int l, int dim, void *params);
+  double (*D2f)(double x, int l, int dim, void *params);
 };
 
 #define PNL_BASIS_MAX_TYPE 10
@@ -808,8 +817,11 @@ static int pnl_basis_type_tab_length = PNL_BASIS_MAX_TYPE; /*!< length of PnlBas
  *
  * @return PNL_OK or PNL_FAIL
  */
-static int pnl_basis_type_register_with_id(int id, const char *label, double (*f)(double x, int l, void *params),
-    double (*Df)(double x, int l, void *params), double (*D2f)(double x, int l, void *params))
+static int pnl_basis_type_register_with_id(int id, const char *label,
+    double (*f)(double x, int l, int dim, void *params),
+    double (*Df)(double x, int l, int dim, void *params),
+    double (*D2f)(double x, int l, int dim, void *params)
+)
 {
   /*
    * Enlarge the array if needed
@@ -858,8 +870,8 @@ static int pnl_basis_type_init()
  *
  * @return the next available index or PNL_BASIS_NULL if an error occurred
  */
-int pnl_basis_type_register(const char *name, double (*f)(double x, int l, void *params),
-    double (*Df)(double x, int l, void *params), double (*D2f)(double x, int l, void *params))
+int pnl_basis_type_register(const char *name, double (*f)(double x, int l, int dim, void *params),
+    double (*Df)(double x, int l, int dim, void *params), double (*D2f)(double x, int l, int dim, void *params))
 {
   int id;
   pnl_basis_type_init();
@@ -1271,11 +1283,11 @@ double pnl_basis_ik(const PnlBasis *b, const double *x, int i, int k)
   if (Tik == 0) return 1.;
   if (b->isreduced == 1)
     {
-      return (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
+      return (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, k, b->params);
     }
   else
     {
-      return (b->f)(x[k], Tik, b->params);
+      return (b->f)(x[k], Tik, k, b->params);
     }
 }
 
@@ -1311,9 +1323,9 @@ double pnl_basis_i_D(const PnlBasis *b, const double *x, int i, int j)
           const int k = b->SpT->J[l];
           const int Tik = b->SpT->array[l];
           if (k == j)
-            aux *= b->scale[k] * (b->Df)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
+            aux *= b->scale[k] * (b->Df)((x[k] - b->center[k]) * b->scale[k], Tik, k, b->params);
           else
-            aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
+            aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, k, b->params);
         }
     }
   else
@@ -1323,9 +1335,9 @@ double pnl_basis_i_D(const PnlBasis *b, const double *x, int i, int j)
           const int k = b->SpT->J[l];
           const int Tik = b->SpT->array[l];
           if (k == j)
-            aux *= (b->Df)(x[k], Tik, b->params);
+            aux *= (b->Df)(x[k], Tik, k, b->params);
           else
-            aux *= (b->f)(x[k], Tik, b->params);
+            aux *= (b->f)(x[k], Tik, k, b->params);
         }
     }
   return aux;
@@ -1361,9 +1373,9 @@ double pnl_basis_i_D2(const PnlBasis *b, const double *x, int i, int j1, int j2)
                 const int k = b->SpT->J[l];
                 const int Tik = b->SpT->array[l];
               if (k == j1)
-                aux *= b->scale[k] * b->scale[k] * (b->D2f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
+                aux *= b->scale[k] * b->scale[k] * (b->D2f)((x[k] - b->center[k]) * b->scale[k], Tik, k, b->params);
               else
-                aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
+                aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, k, b->params);
             }
         }
       else
@@ -1373,9 +1385,9 @@ double pnl_basis_i_D2(const PnlBasis *b, const double *x, int i, int j1, int j2)
               const int k = b->SpT->J[l];
               const int Tik = b->SpT->array[l];
               if (k == j1 || k == j2)
-                aux *= b->scale[k] * (b->Df)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
+                aux *= b->scale[k] * (b->Df)((x[k] - b->center[k]) * b->scale[k], Tik, k, b->params);
               else
-                aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
+                aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, k, b->params);
             }
         }
     }
@@ -1388,9 +1400,9 @@ double pnl_basis_i_D2(const PnlBasis *b, const double *x, int i, int j1, int j2)
               const int k = b->SpT->J[l];
               const int Tik = b->SpT->array[l];
               if (k == j1)
-                aux *= (b->D2f)(x[k], Tik, b->params);
+                aux *= (b->D2f)(x[k], Tik, k, b->params);
               else
-                aux *= (b->f)(x[k], Tik, b->params);
+                aux *= (b->f)(x[k], Tik, k, b->params);
             }
         }
       else
@@ -1400,9 +1412,9 @@ double pnl_basis_i_D2(const PnlBasis *b, const double *x, int i, int j1, int j2)
               const int k = b->SpT->J[l];
               const int Tik = b->SpT->array[l];
               if (k == j1 || k == j2)
-                aux *= (b->Df)(x[k], Tik, b->params);
+                aux *= (b->Df)(x[k], Tik, k, b->params);
               else
-                aux *= (b->f)(x[k], Tik, b->params);
+                aux *= (b->f)(x[k], Tik, k, b->params);
             }
         }
 
@@ -1547,7 +1559,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
             {
               const int k = b->SpT->J[l];
               const int Tik = b->SpT->array[l];
-              f[k] = (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
+              f[k] = (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, k, b->params);
               auxf *= f[k];
             }
         }
@@ -1557,7 +1569,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
             {
               const int k = b->SpT->J[l];
               const int Tik = b->SpT->array[l];
-              f[k] = (b->f)(x[k], Tik, b->params);
+              f[k] = (b->f)(x[k], Tik, k, b->params);
               auxf *= f[k];
             }
         }
@@ -1579,7 +1591,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
               /* gradient */
               if (Tij >= 1)
                 {
-                  Df[j] = b->scale[j] * (b->Df)((x[j] - b->center[j]) * b->scale[j], Tij, b->params);
+                  Df[j] = b->scale[j] * (b->Df)((x[j] - b->center[j]) * b->scale[j], Tij, j, b->params);
                   PNL_LET(grad, j) += a * auxf * Df[j];
                 }
               else
@@ -1588,7 +1600,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
               /* diagonal terms of the Hessian matrix */
               if (Tij >= 2)
                 {
-                  D2f = b->scale[j] * b->scale[j] * (b->D2f)((x[j] - b->center[j]) * b->scale[j], Tij, b->params);
+                  D2f = b->scale[j] * b->scale[j] * (b->D2f)((x[j] - b->center[j]) * b->scale[j], Tij, j, b->params);
                   PNL_MLET(hes, j, j) += a * auxf * D2f;
                 }
             }
@@ -1598,7 +1610,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
               /* gradient */
               if (Tij >= 1)
                 {
-                  Df[j] = (b->Df)(x[j], Tij, b->params);
+                  Df[j] = (b->Df)(x[j], Tij, j, b->params);
                   PNL_LET(grad, j) += a * auxf * Df[j];
                 }
               else
@@ -1607,7 +1619,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
               /* diagonal terms of the Hessian matrix */
               if (Tij >= 2)
                 {
-                  D2f = (b->D2f)(x[j], Tij, b->params);
+                  D2f = (b->D2f)(x[j], Tij, j, b->params);
                   PNL_MLET(hes, j, j) += a * auxf * D2f;
                 }
             }

--- a/src/interpol/basis.c
+++ b/src/interpol/basis.c
@@ -1566,7 +1566,7 @@ double pnl_basis_i_D2(const PnlBasis *b, const double *x, int i, int j1, int j2)
  *
  * @param basis A local basis
  * @param x
- * @return int an integer between -1 and basis->nb_func. The value -1 means that x lies outside of the domain.
+ * @return int an integer between -1 and basis->nb_func - 1. The value -1 means that x lies outside of the domain.
  */
 int pnl_basis_local_get_index(const PnlBasis *basis, const double *x)
 {

--- a/src/interpol/basis.c
+++ b/src/interpol/basis.c
@@ -1931,6 +1931,7 @@ static int pnl_basis_fit_ls_local(const PnlBasis *basis, PnlVect *coef, const Pn
     {
       PNL_LET(coef, k) /= count[k];
     }
+  free(count);
   return PNL_OK;
 }
 

--- a/src/interpol/basis.c
+++ b/src/interpol/basis.c
@@ -1585,7 +1585,7 @@ int pnl_basis_local_get_index(const PnlBasis *basis, const double *x)
         {
           index_per_dim = (int) ((x[i] + 1) * n_intervals[i] / 2.);
         }
-      if (index_per_dim < 0 || index_per_dim > n_intervals[i])
+      if (index_per_dim < 0 || index_per_dim >= n_intervals[i])
         {
           return -1;
         }

--- a/src/interpol/basis.c
+++ b/src/interpol/basis.c
@@ -453,6 +453,7 @@ static PnlMatInt *compute_tensor_from_hyperbolic_degree(double degree, double q,
  *  Canonical polynomials
  *  @param x the address of a real number
  *  @param l the index of the polynomial to be evaluated
+ *  @param params extra parameters
  */
 static double CanonicalD1(double x, int l, void *params)
 {
@@ -463,6 +464,7 @@ static double CanonicalD1(double x, int l, void *params)
  *  First derivative of the Canonical polynomials
  *  @param x the address of a real number
  *  @param l the index of the polynomial whose first derivative is to be evaluated
+ *  @param params extra parameters
  */
 static double DCanonicalD1(double x, int l, void *params)
 {
@@ -474,6 +476,7 @@ static double DCanonicalD1(double x, int l, void *params)
  *  Second derivative of the Canonical polynomials
  *  @param x the address of a real number
  *  @param l the index of the polynomial whose second derivative is to be evaluated
+ *  @param params extra parameters
  */
 static double D2CanonicalD1(double x, int l, void *params)
 {
@@ -509,6 +512,7 @@ static double Hermite_rec(double x, int n, int n0, double *f_n, double *f_n_1)
  *  Hermite polynomials
  *  @param x the address of a real number
  *  @param n the index of the polynomial to be evaluated
+ *  @param params extra parameters
  */
 static double HermiteD1(double x, int n, void *params)
 {
@@ -548,6 +552,7 @@ static double HermiteD1(double x, int n, void *params)
  *  First derivative of the Hermite polynomials
  *  @param x the address of a real number
  *  @param n the index of the polynomial whose derivative is to be evaluated
+ *  @param params extra parameters
  */
 static double DHermiteD1(double x, int n, void *params)
 {
@@ -560,6 +565,7 @@ static double DHermiteD1(double x, int n, void *params)
  *  Second derivative of the Hermite polynomials
  *  @param x the address of a real number
  *  @param n the index of the polynomial whose second derivative is to be evaluated
+ *  @param params extra parameters
  */
 static double D2HermiteD1(double x, int n, void *params)
 {
@@ -595,6 +601,7 @@ static double Tchebychev_rec(double x, int n, int n0, double *f_n0, double *f_n1
  *  Tchebytchev polynomials of any order
  *  @param x the address of a real number
  *  @param n the order of the polynomial to be evaluated
+ *  @param params extra parameters
  */
 static double TchebychevD1(double x, int n, void *params)
 {
@@ -665,6 +672,7 @@ static double DTchebychev_rec(double x, int n, int n0, double *f_n, double *f_n_
  *  First derivative of the Tchebytchev polynomials
  *  @param x the address of a real number
  *  @param n the index of the polynomial whose first derivative is to be evaluated
+ *  @param params extra parameters
  */
 static double DTchebychevD1(double x, int n, void *params)
 {
@@ -710,6 +718,7 @@ static double DTchebychevD1(double x, int n, void *params)
  *  @param n0 rank of initialization
  *  @param f_n used to store the derivative of the polynomial of order n0
  *  @param f_n_1 used to store the derivative of  the polynomial of order n0 - 1
+ *  @param params extra parameters
  */
 static double D2Tchebychev_rec(double x, int n, int n0, double *f_n, double *f_n_1, void *params)
 {
@@ -730,6 +739,7 @@ static double D2Tchebychev_rec(double x, int n, int n0, double *f_n, double *f_n
  *  Second derivative of the Tchebytchev polynomials
  *  @param x the address of a real number
  *  @param n the index of the polynomial whose second derivative is to be evaluated
+ *  @param params extra parameters
  */
 static double D2TchebychevD1(double x, int n, void *params)
 {

--- a/src/interpol/basis.c
+++ b/src/interpol/basis.c
@@ -1561,7 +1561,14 @@ double pnl_basis_i_D2(const PnlBasis *b, const double *x, int i, int j1, int j2)
 
 }
 
-static int pnl_basis_local_get_index(const PnlBasis *basis, const double *x)
+/**
+ * @brief Compute the index of the cell containing x
+ *
+ * @param basis A local basis
+ * @param x
+ * @return int an integer between -1 and basis->nb_func. The value -1 means that x lies outside of the domain.
+ */
+int pnl_basis_local_get_index(const PnlBasis *basis, const double *x)
 {
   int i;
   int index_per_dim, global_index, n_intervals_prod;

--- a/src/interpol/basis.c
+++ b/src/interpol/basis.c
@@ -452,33 +452,33 @@ static PnlMatInt *compute_tensor_from_hyperbolic_degree(double degree, double q,
 /**
  *  Canonical polynomials
  *  @param x the address of a real number
- *  @param ind the index of the polynomial to be evaluated
+ *  @param l the index of the polynomial to be evaluated
  */
-static double CanonicalD1(double x, int ind, void *params)
+static double CanonicalD1(double x, int l, void *params)
 {
-  return pnl_pow_i(x, ind);
+  return pnl_pow_i(x, l);
 }
 
 /**
  *  First derivative of the Canonical polynomials
  *  @param x the address of a real number
- *  @param ind the index of the polynomial whose first derivative is to be evaluated
+ *  @param l the index of the polynomial whose first derivative is to be evaluated
  */
-static double DCanonicalD1(double x, int ind, void *params)
+static double DCanonicalD1(double x, int l, void *params)
 {
-  if (ind == 0) return 0.;
-  return ind * pnl_pow_i(x, ind - 1);
+  if (l == 0) return 0.;
+  return l * pnl_pow_i(x, l - 1);
 }
 
 /**
  *  Second derivative of the Canonical polynomials
  *  @param x the address of a real number
- *  @param ind the index of the polynomial whose second derivative is to be evaluated
+ *  @param l the index of the polynomial whose second derivative is to be evaluated
  */
-static double D2CanonicalD1(double x, int ind, void *params)
+static double D2CanonicalD1(double x, int l, void *params)
 {
-  if (ind <= 1) return 0.;
-  return ind * (ind - 1) * pnl_pow_i(x, ind - 2);
+  if (l <= 1) return 0.;
+  return l * (l - 1) * pnl_pow_i(x, l - 2);
 }
 
 /**
@@ -572,7 +572,7 @@ static double D2HermiteD1(double x, int n, void *params)
  * order.
  * @param x the address of a real number
  * @param n the order of the polynomial to be evaluated
- * @param n0 rank of initilization
+ * @param n0 rank of initialization
  * @param f_n0 used to store the polynomial of order n0
  * @param f_n1 used to store the polynomial of order n0 - 1
  */
@@ -774,9 +774,9 @@ struct PnlBasisType_t
 {
   int id;
   const char *label;
-  double (*f)(double x, int n, void *params);
-  double (*Df)(double x, int n, void *params);
-  double (*D2f)(double x, int n, void *params);
+  double (*f)(double x, int l, void *params);
+  double (*Df)(double x, int l, void *params);
+  double (*D2f)(double x, int l, void *params);
 };
 
 #define PNL_BASIS_MAX_TYPE 10
@@ -798,8 +798,8 @@ static int pnl_basis_type_tab_length = PNL_BASIS_MAX_TYPE; /*!< length of PnlBas
  *
  * @return PNL_OK or PNL_FAIL
  */
-static int pnl_basis_type_register_with_id(int id, const char *label, double (*f)(double, int, void *params),
-    double (*Df)(double, int, void *params), double (*D2f)(double, int, void *params))
+static int pnl_basis_type_register_with_id(int id, const char *label, double (*f)(double x, int l, void *params),
+    double (*Df)(double x, int l, void *params), double (*D2f)(double x, int l, void *params))
 {
   /*
    * Enlarge the array if needed
@@ -848,8 +848,8 @@ static int pnl_basis_type_init()
  *
  * @return the next available index or PNL_BASIS_NULL if an error occurred
  */
-int pnl_basis_type_register(const char *name, double (*f)(double, int, void *params),
-    double (*Df)(double, int, void *params), double (*D2f)(double, int, void *params))
+int pnl_basis_type_register(const char *name, double (*f)(double x, int l, void *params),
+    double (*Df)(double x, int l, void *params), double (*D2f)(double x, int l, void *params))
 {
   int id;
   pnl_basis_type_init();

--- a/src/interpol/basis.c
+++ b/src/interpol/basis.c
@@ -260,7 +260,6 @@ static PnlMatInt *compute_tensor(int nb_func, int nb_variates)
 static int compute_nb_elements(const PnlMatInt *T, int degree,
                                int (*count_degree)(const PnlMatInt *, int),
                                int (*freedom_degree)(int, int))
-
 {
   int i;
   int total_elements; /* Number of elements of total degree smaller than degree */
@@ -373,7 +372,7 @@ static int compute_tensor_from_sum_degree_rec(PnlMatInt *T, int degree, int nb_v
 {
   if (nb_variates <= 0)
     {
-      printf("Nb of variates must be stricly positive in compute_tensor_from_degree\n");
+      printf("Nb of variates must be strictly positive in compute_tensor_from_degree\n");
       abort();
     }
   if (nb_variates == 1)
@@ -455,7 +454,7 @@ static PnlMatInt *compute_tensor_from_hyperbolic_degree(double degree, double q,
  *  @param x the address of a real number
  *  @param ind the index of the polynomial to be evaluated
  */
-static double CanonicalD1(double x, int ind)
+static double CanonicalD1(double x, int ind, void *params)
 {
   return pnl_pow_i(x, ind);
 }
@@ -465,7 +464,7 @@ static double CanonicalD1(double x, int ind)
  *  @param x the address of a real number
  *  @param ind the index of the polynomial whose first derivative is to be evaluated
  */
-static double DCanonicalD1(double x, int ind)
+static double DCanonicalD1(double x, int ind, void *params)
 {
   if (ind == 0) return 0.;
   return ind * pnl_pow_i(x, ind - 1);
@@ -476,7 +475,7 @@ static double DCanonicalD1(double x, int ind)
  *  @param x the address of a real number
  *  @param ind the index of the polynomial whose second derivative is to be evaluated
  */
-static double D2CanonicalD1(double x, int ind)
+static double D2CanonicalD1(double x, int ind, void *params)
 {
   if (ind <= 1) return 0.;
   return ind * (ind - 1) * pnl_pow_i(x, ind - 2);
@@ -511,7 +510,7 @@ static double Hermite_rec(double x, int n, int n0, double *f_n, double *f_n_1)
  *  @param x the address of a real number
  *  @param n the index of the polynomial to be evaluated
  */
-static double HermiteD1(double x, int n)
+static double HermiteD1(double x, int n, void *params)
 {
   double val = x;
   double val2;
@@ -539,8 +538,8 @@ static double HermiteD1(double x, int n)
       val2 = val * val;
       return (((val2 - 21.) * val2 + 105.) * val2 - 105) * val;
     default:
-      f_n = HermiteD1(x, 7);
-      f_n_1 = HermiteD1(x, 6);
+      f_n = HermiteD1(x, 7, params);
+      f_n_1 = HermiteD1(x, 6, params);
       return Hermite_rec(x, n, 7, &f_n, &f_n_1);
     }
 }
@@ -550,10 +549,10 @@ static double HermiteD1(double x, int n)
  *  @param x the address of a real number
  *  @param n the index of the polynomial whose derivative is to be evaluated
  */
-static double DHermiteD1(double x, int n)
+static double DHermiteD1(double x, int n, void *params)
 {
   if (n == 0) return 0.;
-  else return n * HermiteD1(x, n - 1);
+  else return n * HermiteD1(x, n - 1, params);
 
 }
 
@@ -562,10 +561,10 @@ static double DHermiteD1(double x, int n)
  *  @param x the address of a real number
  *  @param n the index of the polynomial whose second derivative is to be evaluated
  */
-static double D2HermiteD1(double x, int n)
+static double D2HermiteD1(double x, int n, void *params)
 {
   if (n == 0 || n == 1) return 0.;
-  return n * (n - 1) * HermiteD1(x, n - 2);
+  return n * (n - 1) * HermiteD1(x, n - 2, params);
 }
 
 /**
@@ -597,7 +596,7 @@ static double Tchebychev_rec(double x, int n, int n0, double *f_n0, double *f_n1
  *  @param x the address of a real number
  *  @param n the order of the polynomial to be evaluated
  */
-static double TchebychevD1(double x, int n)
+static double TchebychevD1(double x, int n, void *params)
 {
   double val = x;
   double val2, val3, val4;
@@ -630,8 +629,8 @@ static double TchebychevD1(double x, int n)
       val4 = val2 * val2;
       return (64. * val4 - 112. * val2 + 56) * val3 - 7. * val;
     default :
-      f_n = TchebychevD1(x, 7);
-      f_n_1 = TchebychevD1(x, 6);
+      f_n = TchebychevD1(x, 7, params);
+      f_n_1 = TchebychevD1(x, 6, params);
       return Tchebychev_rec(x, n, 7, &f_n, &f_n_1);
     }
 }
@@ -667,7 +666,7 @@ static double DTchebychev_rec(double x, int n, int n0, double *f_n, double *f_n_
  *  @param x the address of a real number
  *  @param n the index of the polynomial whose first derivative is to be evaluated
  */
-static double DTchebychevD1(double x, int n)
+static double DTchebychevD1(double x, int n, void *params)
 {
   double val = x;
   double val2, val4;
@@ -696,8 +695,8 @@ static double DTchebychevD1(double x, int n)
       val4 = val2 * val2;
       return (448. * val4 - 560. * val2 + 168) * val2 - 7.;
     default :
-      f_n = DTchebychevD1(x, 7);
-      f_n_1 = DTchebychevD1(x, 6);
+      f_n = DTchebychevD1(x, 7, params);
+      f_n_1 = DTchebychevD1(x, 6, params);
       return DTchebychev_rec(x, n, 7, &f_n, &f_n_1);
     }
 }
@@ -712,7 +711,7 @@ static double DTchebychevD1(double x, int n)
  *  @param f_n used to store the derivative of the polynomial of order n0
  *  @param f_n_1 used to store the derivative of  the polynomial of order n0 - 1
  */
-static double D2Tchebychev_rec(double x, int n, int n0, double *f_n, double *f_n_1)
+static double D2Tchebychev_rec(double x, int n, int n0, double *f_n, double *f_n_1, void *params)
 {
   if (n == n0)
     {
@@ -721,9 +720,9 @@ static double D2Tchebychev_rec(double x, int n, int n0, double *f_n, double *f_n
   else
     {
       double save = *f_n;
-      *f_n = 2 * x * (*f_n) - (*f_n_1) + 4 * DTchebychevD1(x, n0);
+      *f_n = 2 * x * (*f_n) - (*f_n_1) + 4 * DTchebychevD1(x, n0, params);
       *f_n_1 = save;
-      return D2Tchebychev_rec(x, n, n0 + 1, f_n, f_n_1);
+      return D2Tchebychev_rec(x, n, n0 + 1, f_n, f_n_1, params);
     }
 }
 
@@ -732,7 +731,7 @@ static double D2Tchebychev_rec(double x, int n, int n0, double *f_n, double *f_n
  *  @param x the address of a real number
  *  @param n the index of the polynomial whose second derivative is to be evaluated
  */
-static double D2TchebychevD1(double x, int n)
+static double D2TchebychevD1(double x, int n, void *params)
 {
   double val = x;
   double val2, val4;
@@ -761,9 +760,9 @@ static double D2TchebychevD1(double x, int n)
       val4 = val2 * val2;
       return (2688. * val4 - 2240. * val2 + 336) * val;
     default :
-      f_n = D2TchebychevD1(x, 7);
-      f_n_1 = D2TchebychevD1(x, 6);
-      return D2Tchebychev_rec(x, n, 7, &f_n, &f_n_1);
+      f_n = D2TchebychevD1(x, 7, params);
+      f_n_1 = D2TchebychevD1(x, 6, params);
+      return D2Tchebychev_rec(x, n, 7, &f_n, &f_n_1, params);
     }
 }
 
@@ -775,9 +774,9 @@ struct PnlBasisType_t
 {
   int id;
   const char *label;
-  double (*f)(double x, int n);
-  double (*Df)(double x, int n);
-  double (*D2f)(double x, int n);
+  double (*f)(double x, int n, void *params);
+  double (*Df)(double x, int n, void *params);
+  double (*D2f)(double x, int n, void *params);
 };
 
 #define PNL_BASIS_MAX_TYPE 10
@@ -785,7 +784,7 @@ struct PnlBasisType_t
  * The array holding the different basis types registered so far
  */
 static PnlBasisType *PnlBasisTypeTab = NULL;
-static int pnl_basis_type_next = 0; /*!< next availble id for a basis type */
+static int pnl_basis_type_next = 0; /*!< next available id for a basis type */
 static int pnl_basis_type_tab_length = PNL_BASIS_MAX_TYPE; /*!< length of PnlBasisTypeTab */
 
 /**
@@ -799,8 +798,8 @@ static int pnl_basis_type_tab_length = PNL_BASIS_MAX_TYPE; /*!< length of PnlBas
  *
  * @return PNL_OK or PNL_FAIL
  */
-static int pnl_basis_type_register_with_id(int id, const char *label, double (*f)(double, int),
-    double (*Df)(double, int), double (*D2f)(double, int))
+static int pnl_basis_type_register_with_id(int id, const char *label, double (*f)(double, int, void *params),
+    double (*Df)(double, int, void *params), double (*D2f)(double, int, void *params))
 {
   /*
    * Enlarge the array if needed
@@ -849,8 +848,8 @@ static int pnl_basis_type_init()
  *
  * @return the next available index or PNL_BASIS_NULL if an error occurred
  */
-int pnl_basis_type_register(const char *name, double (*f)(double, int),
-                            double (*Df)(double, int), double (*D2f)(double, int))
+int pnl_basis_type_register(const char *name, double (*f)(double, int, void *params),
+    double (*Df)(double, int, void *params), double (*D2f)(double, int, void *params))
 {
   int id;
   pnl_basis_type_init();
@@ -884,6 +883,8 @@ PnlBasis *pnl_basis_new()
   o->func_list = NULL;
   o->len_func_list = 0;
   o->len_T = 0;
+  o->params = NULL;
+  o->params_size = 0;
   o->object.type = PNL_TYPE_BASIS;
   o->object.parent_type = PNL_TYPE_BASIS;
   o->object.label = pnl_basis_label;
@@ -900,7 +901,7 @@ PnlBasis *pnl_basis_new()
  *
  * @param b an already allocated basis (as returned by pnl_basis_new for instance)
  * @param index the index of the family to be used
- * @param T the tensor of the multi-dimensionnal basis. No copy of T is done, so
+ * @param T the tensor of the multi-dimensional basis. No copy of T is done, so
  * do not free T. It will be freed transparently by pnl_basis_free
  */
 void  pnl_basis_set_from_tensor(PnlBasis *b, int index, const PnlMatInt *T)
@@ -937,7 +938,7 @@ void  pnl_basis_set_from_tensor(PnlBasis *b, int index, const PnlMatInt *T)
  * Return a  PnlBasis
  *
  * @param index the index of the family to be used
- * @param T the tensor of the multi-dimensionnal basis. No copy of T is done, so
+ * @param T the tensor of the multi-dimensional basis. No copy of T is done, so
  * do not free T. It will be freed transparently by pnl_basis_free
  * @return a PnlBasis
  */
@@ -1044,6 +1045,8 @@ void pnl_basis_add_function(PnlBasis *b, PnlRnFuncR *f)
 void pnl_basis_clone(PnlBasis *dest, const PnlBasis *src)
 {
   pnl_basis_set_from_tensor(dest, src->id, src->T);
+  dest->params = realloc(dest->params, src->params_size);
+  dest->params_size = src->params_size;
   if (src->isreduced == 1)
     {
       int n = dest->nb_variates;
@@ -1187,6 +1190,11 @@ void pnl_basis_free(PnlBasis **B)
   if (*B == NULL) return;
   pnl_mat_int_free(&((*B)->T));
   pnl_sp_mat_int_free(&(*B)->SpT);
+  if ((*B)->params_size > 0) {
+    free((*B)->params);
+    (*B)->params = NULL;
+    (*B)->params_size = 0;
+  }
   if ((*B)->isreduced == 1)
     {
       free((*B)->center);
@@ -1205,11 +1213,12 @@ void pnl_basis_free(PnlBasis **B)
  */
 void pnl_basis_print(const PnlBasis *B)
 {
-  printf("Basis Name : %s\n", B->label);
-  printf("\tNumber of variates : %d\n", B->nb_variates);
+  printf("Basis Name: %s\n", B->label);
+  printf("\tNumber of variates: %d\n", B->nb_variates);
+  printf("\tExtra parameters size: %zu\n", B->params_size);
   printf("\tNumber of functions in tensor: %d\n", B->len_T);;
-  printf("\tNumber of extra functions : %d\n", B->len_func_list);
-  printf("\tTotal number of functions : %d\n", B->nb_func);
+  printf("\tNumber of extra functions: %d\n", B->len_func_list);
+  printf("\tTotal number of functions: %d\n", B->nb_func);
   printf("\tisreduced = %d\n", B->isreduced);
   if (B->isreduced)
     {
@@ -1252,11 +1261,11 @@ double pnl_basis_ik(const PnlBasis *b, const double *x, int i, int k)
   if (Tik == 0) return 1.;
   if (b->isreduced == 1)
     {
-      return (b->f)((x[k] - b->center[k]) * b->scale[k], Tik);
+      return (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
     }
   else
     {
-      return (b->f)(x[k], Tik);
+      return (b->f)(x[k], Tik, b->params);
     }
 }
 
@@ -1292,9 +1301,9 @@ double pnl_basis_i_D(const PnlBasis *b, const double *x, int i, int j)
           const int k = b->SpT->J[l];
           const int Tik = b->SpT->array[l];
           if (k == j)
-            aux *= b->scale[k] * (b->Df)((x[k] - b->center[k]) * b->scale[k], Tik);
+            aux *= b->scale[k] * (b->Df)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
           else
-            aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik);
+            aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
         }
     }
   else
@@ -1304,9 +1313,9 @@ double pnl_basis_i_D(const PnlBasis *b, const double *x, int i, int j)
           const int k = b->SpT->J[l];
           const int Tik = b->SpT->array[l];
           if (k == j)
-            aux *= (b->Df)(x[k], Tik);
+            aux *= (b->Df)(x[k], Tik, b->params);
           else
-            aux *= (b->f)(x[k], Tik);
+            aux *= (b->f)(x[k], Tik, b->params);
         }
     }
   return aux;
@@ -1342,9 +1351,9 @@ double pnl_basis_i_D2(const PnlBasis *b, const double *x, int i, int j1, int j2)
                 const int k = b->SpT->J[l];
                 const int Tik = b->SpT->array[l];
               if (k == j1)
-                aux *= b->scale[k] * b->scale[k] * (b->D2f)((x[k] - b->center[k]) * b->scale[k], Tik);
+                aux *= b->scale[k] * b->scale[k] * (b->D2f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
               else
-                aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik);
+                aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
             }
         }
       else
@@ -1354,9 +1363,9 @@ double pnl_basis_i_D2(const PnlBasis *b, const double *x, int i, int j1, int j2)
               const int k = b->SpT->J[l];
               const int Tik = b->SpT->array[l];
               if (k == j1 || k == j2)
-                aux *= b->scale[k] * (b->Df)((x[k] - b->center[k]) * b->scale[k], Tik);
+                aux *= b->scale[k] * (b->Df)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
               else
-                aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik);
+                aux *= (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
             }
         }
     }
@@ -1369,9 +1378,9 @@ double pnl_basis_i_D2(const PnlBasis *b, const double *x, int i, int j1, int j2)
               const int k = b->SpT->J[l];
               const int Tik = b->SpT->array[l];
               if (k == j1)
-                aux *= (b->D2f)(x[k], Tik);
+                aux *= (b->D2f)(x[k], Tik, b->params);
               else
-                aux *= (b->f)(x[k], Tik);
+                aux *= (b->f)(x[k], Tik, b->params);
             }
         }
       else
@@ -1381,9 +1390,9 @@ double pnl_basis_i_D2(const PnlBasis *b, const double *x, int i, int j1, int j2)
               const int k = b->SpT->J[l];
               const int Tik = b->SpT->array[l];
               if (k == j1 || k == j2)
-                aux *= (b->Df)(x[k], Tik);
+                aux *= (b->Df)(x[k], Tik, b->params);
               else
-                aux *= (b->f)(x[k], Tik);
+                aux *= (b->f)(x[k], Tik, b->params);
             }
         }
 
@@ -1486,7 +1495,7 @@ double pnl_basis_eval_D2(const PnlBasis *basis, const PnlVect *coef, const doubl
 
 /**
  * Evaluate the function, its gradient and Hessian matrix at x. The function is
- * defined by  linear combination sum (coef .* f(x))
+ * defined by the linear combination sum (coef .* f(x))
  *
  * @deprecated Use the function pnl_basis_eval_derivs_vect(const PnlBasis *b, const PnlVect *coef, const PnlVect *x, double *val, PnlVect *grad, PnlMat *hes)
  *
@@ -1528,7 +1537,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
             {
               const int k = b->SpT->J[l];
               const int Tik = b->SpT->array[l];
-              f[k] = (b->f)((x[k] - b->center[k]) * b->scale[k], Tik);
+              f[k] = (b->f)((x[k] - b->center[k]) * b->scale[k], Tik, b->params);
               auxf *= f[k];
             }
         }
@@ -1538,7 +1547,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
             {
               const int k = b->SpT->J[l];
               const int Tik = b->SpT->array[l];
-              f[k] = (b->f)(x[k], Tik);
+              f[k] = (b->f)(x[k], Tik, b->params);
               auxf *= f[k];
             }
         }
@@ -1560,7 +1569,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
               /* gradient */
               if (Tij >= 1)
                 {
-                  Df[j] = b->scale[j] * (b->Df)((x[j] - b->center[j]) * b->scale[j], Tij);
+                  Df[j] = b->scale[j] * (b->Df)((x[j] - b->center[j]) * b->scale[j], Tij, b->params);
                   PNL_LET(grad, j) += a * auxf * Df[j];
                 }
               else
@@ -1569,7 +1578,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
               /* diagonal terms of the Hessian matrix */
               if (Tij >= 2)
                 {
-                  D2f = b->scale[j] * b->scale[j] * (b->D2f)((x[j] - b->center[j]) * b->scale[j], Tij);
+                  D2f = b->scale[j] * b->scale[j] * (b->D2f)((x[j] - b->center[j]) * b->scale[j], Tij, b->params);
                   PNL_MLET(hes, j, j) += a * auxf * D2f;
                 }
             }
@@ -1579,7 +1588,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
               /* gradient */
               if (Tij >= 1)
                 {
-                  Df[j] = (b->Df)(x[j], Tij);
+                  Df[j] = (b->Df)(x[j], Tij, b->params);
                   PNL_LET(grad, j) += a * auxf * Df[j];
                 }
               else
@@ -1588,7 +1597,7 @@ void pnl_basis_eval_derivs(const PnlBasis *b, const PnlVect *coef, const double 
               /* diagonal terms of the Hessian matrix */
               if (Tij >= 2)
                 {
-                  D2f = (b->D2f)(x[j], Tij);
+                  D2f = (b->D2f)(x[j], Tij, b->params);
                   PNL_MLET(hes, j, j) += a * auxf * D2f;
                 }
             }

--- a/src/interpol/basis.c
+++ b/src/interpol/basis.c
@@ -922,14 +922,12 @@ PnlBasis *pnl_basis_new()
  * Create a PnlBasis and stores it into its first argument
  *
  * @param b an already allocated basis (as returned by pnl_basis_new for instance)
- * @param index the index of the family to be used
  * @param T the tensor of the multi-dimensional basis. No copy of T is done, so
  * do not free T. It will be freed transparently by pnl_basis_free
  */
-void  pnl_basis_set_from_tensor(PnlBasis *b, int index, const PnlMatInt *T)
+void  pnl_basis_set_from_tensor(PnlBasis *b, const PnlMatInt *T)
 {
   b->nb_func = T->m;
-  b->id = index;
   b->nb_variates = T->n;
   if(b->func_list) free(b->func_list);
   b->len_func_list = 0;
@@ -950,10 +948,22 @@ void  pnl_basis_set_from_tensor(PnlBasis *b, int index, const PnlMatInt *T)
   b->T = (PnlMatInt *) T;
   b->SpT = pnl_sp_mat_int_create_from_mat(T);
 
-  b->label = PnlBasisTypeTab[index].label;
-  b->f = PnlBasisTypeTab[index].f;
-  b->Df = PnlBasisTypeTab[index].Df;
-  b->D2f = PnlBasisTypeTab[index].D2f;
+}
+
+/**
+ * Set the type of basis
+ *
+ * @param B a PnlBasis
+ * @param index the index of the family to be used
+ */
+void pnl_basis_set_type(PnlBasis *B, int index)
+{
+  B->id = index;
+  B->label = PnlBasisTypeTab[index].label;
+  B->f = PnlBasisTypeTab[index].f;
+  B->Df = PnlBasisTypeTab[index].Df;
+  B->D2f = PnlBasisTypeTab[index].D2f;
+
 }
 
 /**
@@ -968,7 +978,8 @@ PnlBasis *pnl_basis_create_from_tensor(int index, const PnlMatInt *T)
 {
   PnlBasis *b;
   if ((b = pnl_basis_new()) == NULL) return NULL;
-  pnl_basis_set_from_tensor(b, index, T);
+  pnl_basis_set_from_tensor(b, T);
+  pnl_basis_set_type(b, index);
   return b;
 }
 
@@ -1066,7 +1077,12 @@ void pnl_basis_add_function(PnlBasis *b, PnlRnFuncR *f)
  */
 void pnl_basis_clone(PnlBasis *dest, const PnlBasis *src)
 {
-  pnl_basis_set_from_tensor(dest, src->id, src->T);
+  pnl_basis_set_from_tensor(dest, src->T);
+  dest->id = src->id;
+  dest->label = src->label;
+  dest->f = src->f;
+  dest->Df = src->Df;
+  dest->D2f = src->D2f;
   dest->params = realloc(dest->params, src->params_size);
   dest->params_size = src->params_size;
   if (src->isreduced == 1)


### PR DESCRIPTION
This PR adds tensor local functions. 

- In dimension 1, these functions are piecewise constant over a regular grid of `(-1,1)`. 
- In the multi-dimensional case, the grid may not have the same size in all dimensions.
- These functions are not differentiable. Calling any of the functions `pnl_basis_i_D*` or `pnl_basis_eval_D*` results in raising an abort error.
- The signature of `pnl_basis_type_register` is changed to allow `1d` to take extra arguments `double f(double x, int n, int dim, void *params)`
  - `x` is the value of the `dim-`coordinate of the point at which the tensor function is evaluated
  - `n` is the index of the function
  - `params` is a generic pointer to pass the extra arguments `PnlBasis.params`.